### PR TITLE
Use dash-q in version names

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "hyper",
   "productName": "Hyper",
   "description": "A terminal built on web technologies",
-  "version": "4.0.0q-canary.6",
+  "version": "4.0.0-q-canary.6",
   "license": "MIT",
   "author": {
     "name": "ZEIT, Inc.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper",
-  "version": "4.0.0q-canary.6",
+  "version": "4.0.0-q-canary.6",
   "repository": "quine-global/hyper",
   "scripts": {
     "start": "echo 'please run `yarn run dev` in one tab and then `yarn run app` in another one'",


### PR DESCRIPTION
The infrastructure expects a dash before the q.