### PR TITLE
Windows compatibility fixes

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -20,7 +20,7 @@
     "chokidar": "^3.6.0",
     "color": "4.2.3",
     "default-shell": "1.0.1",
-    "electron-devtools-installer": "3.2.0",
+    "electron-devtools-installer": "3.2.1",
     "quine-electron-drag-click": "1.0.6d",
     "electron-fetch": "1.9.1",
     "electron-is-dev": "2.0.0",

--- a/app/ui/window.ts
+++ b/app/ui/window.ts
@@ -27,7 +27,9 @@ import toElectronBackgroundColor from '../utils/to-electron-background-color';
 
 import contextMenuTemplate from './contextmenu';
 
-electronDragClick();
+if(process.platform === 'darwin') {
+  electronDragClick();
+}
 
 export function newWindow(
   options_: BrowserWindowConstructorOptions,


### PR DESCRIPTION
On Windows, we don't need electron-drag-click (it isn't compatible anyway), and also update devtools installer to resolve "Invalid header: Does not start with Cr24" (https://github.com/MarshallOfSound/electron-devtools-installer/issues/249)