### PR TITLE
Fix macOS 26 GPU performance issue by upgrading to Electron 38

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -190,7 +190,7 @@ app.on('ready', () =>
               }
             }
           ]);
-          app.dock.setMenu(dockMenu);
+          app.dock?.setMenu(dockMenu);
         }
 
         Menu.setApplicationMenu(AppMenu.buildMenu(menu));

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@babel/plugin-proposal-optional-chaining": "7.21.0",
     "@babel/preset-react": "7.25.9",
     "@babel/preset-typescript": "7.26.0",
-    "@electron/rebuild": "^3.7.1",
+    "@electron/rebuild": "^3.7.2",
     "@types/args": "5.0.3",
     "@types/async-retry": "1.4.9",
     "@types/color": "3.0.6",
@@ -115,10 +115,10 @@
     "copy-webpack-plugin": "12.0.2",
     "cpy-cli": "^5.0.0",
     "cross-env": "7.0.3",
-    "electron": "34.5.1",
+    "electron": "38.6.0",
     "electron-builder": "26.0.13",
     "electron-link": "^0.6.0",
-    "electron-mksnapshot": "34.5.1",
+    "electron-mksnapshot": "38.6.0",
     "electronmon": "^2.0.3",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
@@ -158,7 +158,7 @@
   },
   "resolutions": {
     "@types/retry": "0.12.5",
-    "node-abi": "^3.67.0"
+    "node-abi": "^3.81.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,7 +571,7 @@
     minimist "^1.2.6"
     plist "^3.0.5"
 
-"@electron/rebuild@3.7.2", "@electron/rebuild@^3.7.1":
+"@electron/rebuild@3.7.2", "@electron/rebuild@^3.7.2":
   version "3.7.2"
   resolved "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.2.tgz#8d808b29159c50086d27a5dec72b40bf16b4b582"
   integrity sha512-19/KbIR/DAxbsCkiaGMXIdPnMCJLkcf8AvGnduJtWBs/CBwiAjY1apCqOLVxrXg+rtXFCngbXhBanWjxLUt1Mg==
@@ -1285,12 +1285,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^20.9.0":
-  version "20.17.30"
-  resolved "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz#1d93f656d3b869dbef7b796568ac457606ba58d0"
-  integrity sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==
+"@types/node@^22.7.7":
+  version "22.19.1"
+  resolved "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz#1188f1ddc9f46b4cc3aec76749050b4e1f459b7b"
+  integrity sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==
   dependencies:
-    undici-types "~6.19.2"
+    undici-types "~6.21.0"
 
 "@types/parse-path@^7.0.0":
   version "7.0.3"
@@ -3354,10 +3354,10 @@ electron-link@^0.6.0:
     resolve "^1.19.0"
     source-map "^0.7.3"
 
-electron-mksnapshot@34.5.1:
-  version "34.5.1"
-  resolved "https://registry.npmjs.org/electron-mksnapshot/-/electron-mksnapshot-34.5.1.tgz#25fd5e935e9566d8ce157cb173643b0a9cf904e4"
-  integrity sha512-kD8VQLe/7vMw3ddAnJqcnseFQohTdZJSUgyoQpPwRa9fUf2Ko1sXBP9mriQjjw4Ho5SmKqaAz4rJMAUgsxf51Q==
+electron-mksnapshot@38.6.0:
+  version "38.6.0"
+  resolved "https://registry.npmjs.org/electron-mksnapshot/-/electron-mksnapshot-38.6.0.tgz#ae9b20caa38087e157aba01607a85326d14d26d9"
+  integrity sha512-2/TpAa4iZ9roln5fTcAEsZrgaUSliglbWkyow/ae+yij6RHJO0dFzKihynSynLnEXgOPRQT6zrqKV53TTQOufA==
   dependencies:
     "@electron/get" "^2.0.1"
     extract-zip "^2.0.0"
@@ -3403,13 +3403,13 @@ electron-to-chromium@^1.5.73:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.139.tgz#56ae7d42439e2967a54badbadaeb12f748987f37"
   integrity sha512-GGnRYOTdN5LYpwbIr0rwP/ZHOQSvAF6TG0LSzp28uCBb9JiXHJGmaaKw29qjNJc5bGnnp6kXJqRnGMQoELwi5w==
 
-electron@34.5.1:
-  version "34.5.1"
-  resolved "https://registry.npmjs.org/electron/-/electron-34.5.1.tgz#c7ce7b6f054eae6c7ef2d4ee933277db5bf069b3"
-  integrity sha512-z2Wm7QjhnJ5592fLITynj8UwIk1mBiT402mOakxSYiADrERIci3IOPk7xWHAFOMvt/eoG5RW16PPhgJiedZcGA==
+electron@38.6.0:
+  version "38.6.0"
+  resolved "https://registry.npmjs.org/electron/-/electron-38.6.0.tgz#c862bff41d42776e307bf5cc92503dda23612339"
+  integrity sha512-68OFNxJlrEStA+t8k5atzf4frJddvRR1N1oalr49Ll8YZ0+0nEsDhw4UNhTCoZKTjSYcxFF/4rt+sco+OlnB3g==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^20.9.0"
+    "@types/node" "^22.7.7"
     extract-zip "^2.0.1"
 
 electronmon@^2.0.3:
@@ -6085,10 +6085,10 @@ nested-error-stacks@^2.1.1:
   resolved "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz#26c8a3cee6cc05fbcf1e333cd2fc3e003326c0b5"
   integrity sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==
 
-node-abi@^3.0.0, node-abi@^3.45.0, node-abi@^3.67.0:
-  version "3.74.0"
-  resolved "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz#5bfb4424264eaeb91432d2adb9da23c63a301ed0"
-  integrity sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==
+node-abi@^3.0.0, node-abi@^3.45.0, node-abi@^3.81.0:
+  version "3.81.0"
+  resolved "https://registry.npmjs.org/node-abi/-/node-abi-3.81.0.tgz#176a80904b2d382f5e5d1abcfb44d681cf9105c5"
+  integrity sha512-I+SHs7vmUV9ooMDHVzFfUxFQRWeiBCGbI02+XB503WBS8RCDJl4vXSoAXzcnSWpzgItirp2EraDq7jQ2c7CIiA==
   dependencies:
     semver "^7.3.5"
 
@@ -8274,7 +8274,7 @@ undici-types@~5.26.4:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
-undici-types@~6.19.2, undici-types@~6.19.8:
+undici-types@~6.19.8:
   version "6.19.8"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==


### PR DESCRIPTION
## Summary

This PR upgrades Electron from 34.5.1 to 38.6.0 to resolve excessive WindowServer GPU usage on macOS 26 (Sequoia).

## Problem

On macOS 26, Hyper was experiencing significant GPU performance issues due to Electron's override of the private `_cornerMask` API. This override forced the compositor to treat window masks as dynamic rather than static, resulting in persistent high GPU load from WindowServer.

## Solution

Upgraded to Electron 38.6.0, which includes the fix introduced in [electron/electron#48376](https://github.com/electron/electron/pull/48376).

## Changes

- Upgrade `electron`: 34.5.1 → 38.6.0
- Upgrade `electron-mksnapshot`: 34.5.1 → 38.6.0
- Upgrade `@electron/rebuild`: ^3.7.1 → ^3.7.2
- Upgrade `node-abi`: ^3.67.0 → ^3.81.0 (required for Electron 38 support)

## Version Selection

The fix was introduced in Electron 36.9.2, 37.6.0, 38.2.0, and all later versions. We're upgrading to 38.6.0 as it's the latest stable version compatible with Node 20.11.0 (required by Hyper). Newer versions (39+) require Node 22.12.0+.

## Testing

- ✅ Build successful on macOS 26 with Apple Silicon
- ✅ Application launches and runs correctly
- ✅ GPU performance improved (normal WindowServer usage)
- ✅ All native modules (node-pty) rebuilt successfully

## References

Fixes: electron/electron#48376