### PR TITLE
ci: replace GabrielBB/xvfb-action with inline xvfb-run

### DIFF
--- a/.github/actions/build-linux-arm/action.yml
+++ b/.github/actions/build-linux-arm/action.yml
@@ -62,7 +62,7 @@ runs:
         yarn install
         sudo apt update
         sudo apt install libarchive-tools
-    
+
     - name: Rebuild node-pty and all native modules for ARM
       uses: pguyot/arm-runner-action@v2.6.5
       with:
@@ -77,7 +77,7 @@ runs:
           sudo apt-get update
           sudo apt-get install -y python3-pip python3-setuptools python3-dev
           pip3 install setuptools --break-system-packages || pip3 install setuptools
-          
+
           cd target
           wget https://nodejs.org/dist/v22.11.0/node-v22.11.0-linux-${{ inputs.matrix-name }}.tar.xz
           tar -xJf node-v22.11.0-linux-${{ inputs.matrix-name }}.tar.xz
@@ -107,7 +107,7 @@ runs:
         sudo apt update
         sudo apt install -y libglib2.0-0:i386 libexpat1:i386 libgcc-s1:i386
         SNAPSHOT_TARGET_ARCH=armv7l yarn run v8-snapshot:arch
-    
+
     - name: Build final Electron App for ARM
       shell: bash
       run: |
@@ -129,8 +129,5 @@ runs:
 
 #    - name: Run E2E Tests on Linux
 #      if: runner.os == 'Linux'
-#      uses: GabrielBB/xvfb-action@v1.7
-#      with:
-#        run: |
-#          yarn run test
-#
+#      shell: bash
+#      run: xvfb-run -a yarn run test

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -124,10 +124,8 @@ runs:
 
     - name: Run E2E Tests on Linux
       if: runner.os == 'Linux'
-      uses: GabrielBB/xvfb-action@v1.7
-      with:
-        run: |
-          yarn run test:e2e
+      shell: bash
+      run: xvfb-run -a yarn run test:e2e
       env:
         SHELL: /bin/bash
         DEBUG: "pw:browser*"


### PR DESCRIPTION
<!-- Please check `Allow edits from maintainers`. Thanks! -->
`xvfb` is pre-installed on `ubuntu-latest` GitHub-hosted runners (see the runner-images Ubuntu 24.04 [Readme](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#installed-apt-packages)).