### PR TITLE
fix(ci): fix release job skipping and pnpm cache issues

### DIFF
--- a/.github/actions/build-linux-arm/action.yml
+++ b/.github/actions/build-linux-arm/action.yml
@@ -49,9 +49,9 @@ runs:
     - uses: actions/cache/restore@v5.0.5
       with:
         path: ${{ steps.pnpm-store-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml', 'app/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml', 'app/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-pnpm-
+          ${{ runner.os }}-pnpm-store-
 
     - name: Delete old electron headers
       # These can sometimes be present on a freshly-provisioned github runner, so remove them
@@ -130,6 +130,12 @@ runs:
           dist/*.deb
           dist/*.rpm
           dist/*.pacman
+
+    - uses: actions/cache/save@v5.0.5
+      if: github.event_name != 'pull_request'
+      with:
+        path: ${{ steps.pnpm-store-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml', 'app/pnpm-lock.yaml') }}
 
 #    - name: Run E2E Tests on Linux
 #      if: runner.os == 'Linux'

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -50,9 +50,9 @@ runs:
     - uses: actions/cache/restore@v5.0.5
       with:
         path: ${{ steps.pnpm-store-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml', 'app/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml', 'app/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-pnpm-
+          ${{ runner.os }}-pnpm-store-
 
     - name: Delete old electron headers
       # These can sometimes be present on a freshly-provisioned github runner, so remove them
@@ -155,7 +155,7 @@ runs:
         path: ./pr_num.txt
 
     - uses: actions/cache/save@v5.0.5
-      if: github.event_name == 'push'
+      if: github.event_name != 'pull_request'
       with:
         path: ${{ steps.pnpm-store-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml', 'app/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml', 'app/pnpm-lock.yaml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,7 @@ jobs:
       - build
       - build-linux-armv7l
       - build-linux-arm64
+    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'skipped')
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
- Add explicit `if` to upload-release job so it isn't skipped when validate-tag is skipped (canary branch triggers workflow_dispatch)
- Bust pnpm cache key prefix (pnpm- → pnpm-store-) to avoid deserialization failures from old actions/cache v3/v4 entries
- Allow cache saves on workflow_dispatch in addition to push
- Add missing cache/save step to build-linux-arm action

