### PR TITLE
SSL certificate fix

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -105,7 +105,8 @@ const lsRemote = (pattern?: string) => {
     (pattern && `${pattern}+`) || ''
   }keywords:hyper-plugin,hyper-theme&size=250`;
   type npmResult = {package: {name: string; description: string}};
-  return got(URL)
+  const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0';
+  return got(URL, {https: {rejectUnauthorized}})
     .then((response) => JSON.parse(response.body).results as npmResult[])
     .then((entries) => entries.map((entry) => entry.package))
     .then((entries) =>
@@ -135,9 +136,14 @@ args.command(
           console.log(msg);
         }
       })
-      .catch((err) => {
+      .catch((err: Error) => {
         spinner.fail();
-        console.error(chalk.red(err)); // TODO
+        if (err.message.includes('certificate') || err.message.includes('self signed')) {
+          console.error(chalk.red('SSL certificate error: ' + err.message));
+          console.error(chalk.yellow('If you are behind a corporate proxy, try: NODE_TLS_REJECT_UNAUTHORIZED=0 hyper search'));
+        } else {
+          console.error(chalk.red(err.message));
+        }
       });
   },
   ['s']
@@ -155,9 +161,14 @@ args.command(
         spinner.succeed();
         console.log(msg);
       })
-      .catch((err) => {
+      .catch((err: Error) => {
         spinner.fail();
-        console.error(chalk.red(err)); // TODO
+        if (err.message.includes('certificate') || err.message.includes('self signed')) {
+          console.error(chalk.red('SSL certificate error: ' + err.message));
+          console.error(chalk.yellow('If you are behind a corporate proxy, try: NODE_TLS_REJECT_UNAUTHORIZED=0 hyper ls-remote'));
+        } else {
+          console.error(chalk.red(err.message));
+        }
       });
   },
   ['lsr', 'ls-remote']


### PR DESCRIPTION
Claude says:

SSL certificate warning
Corporate proxies that perform SSL inspection intercept HTTPS traffic
and re-encrypt it using a self-signed certificate chain. Node.js has its
own trust store separate from the OS/browser, so it rejects these certs
by default, causing `hyper search` to fail with:

  RequestError: self signed certificate in certificate chain

Two fixes:
1. Pass `https: { rejectUnauthorized }` to got, reading from
   NODE_TLS_REJECT_UNAUTHORIZED. Setting that env var to '0' bypasses
   SSL verification for the npms.io search request.
2. Detect certificate errors in the search/ls-remote error handlers and
   print an actionable hint instead of the raw error object.

The proper long-term fix is to add the corporate CA cert to Node's trust
store via NODE_EXTRA_CA_CERTS. See also issue https://github.com/quine-global/hyper/issues/316 which tracks replacing
got with native fetch (which requires a different approach to SSL bypass
via a custom undici.Agent).